### PR TITLE
chore: prilux-vial-ui to 0.0.322

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -12,7 +12,7 @@ dependencies:
   version: 0.0.501
 - name: prilux-vial-ui
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.320
+  version: 0.0.322
 - name: priluxswiftlibrary
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.247


### PR DESCRIPTION
chore: Promote prilux-vial-ui to version 0.0.322